### PR TITLE
Split test workflow into separate focused workflows

### DIFF
--- a/.github/workflows/format.yml
+++ b/.github/workflows/format.yml
@@ -1,0 +1,39 @@
+name: Format
+
+permissions:
+  contents: read
+
+on:
+  push:
+    branches: [ main ]
+  pull_request:
+    branches: [ main ]
+
+jobs:
+  format-check:
+    name: Check Formatting
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+
+      - uses: actions/setup-go@v5
+        with:
+          go-version-file: go.mod
+
+      - name: Check gofmt
+        run: |
+          if [ -n "$(gofmt -l .)" ]; then
+            echo "Go code is not formatted:"
+            gofmt -d .
+            exit 1
+          fi
+
+      - name: Check goimports
+        run: |
+          go install golang.org/x/tools/cmd/goimports@latest
+          if [ -n "$(goimports -l .)" ]; then
+            echo "Go imports are not formatted:"
+            goimports -d .
+            exit 1
+          fi
+

--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -1,0 +1,29 @@
+name: Lint
+
+permissions:
+  contents: read
+
+on:
+  push:
+    branches: [ main ]
+  pull_request:
+    branches: [ main ]
+
+jobs:
+  lint-go:
+    name: Lint Go
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+
+      - uses: actions/setup-go@v5
+        with:
+          go-version-file: go.mod
+          cache: true
+
+      - name: golangci-lint
+        uses: golangci/golangci-lint-action@v6
+        with:
+          version: latest
+          args: --timeout=5m
+

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -1,4 +1,5 @@
-name: Test and Lint
+name: Test
+
 permissions:
   contents: read
 
@@ -10,7 +11,7 @@ on:
 
 jobs:
   test:
-    name: Test
+    name: Run Tests
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v4
@@ -46,48 +47,3 @@ jobs:
           file: ./coverage.out
           flags: unittests
           name: codecov-gh-talk
-
-  lint:
-    name: Lint Go
-    runs-on: ubuntu-latest
-    steps:
-      - uses: actions/checkout@v4
-
-      - uses: actions/setup-go@v5
-        with:
-          go-version-file: go.mod
-          cache: true
-
-      - name: golangci-lint
-        uses: golangci/golangci-lint-action@v6
-        with:
-          version: latest
-          args: --timeout=5m
-
-  format-check:
-    name: Format Check
-    runs-on: ubuntu-latest
-    steps:
-      - uses: actions/checkout@v4
-
-      - uses: actions/setup-go@v5
-        with:
-          go-version-file: go.mod
-
-      - name: Check gofmt
-        run: |
-          if [ -n "$(gofmt -l .)" ]; then
-            echo "Go code is not formatted:"
-            gofmt -d .
-            exit 1
-          fi
-
-      - name: Check goimports
-        run: |
-          go install golang.org/x/tools/cmd/goimports@latest
-          if [ -n "$(goimports -l .)" ]; then
-            echo "Go imports are not formatted:"
-            goimports -d .
-            exit 1
-          fi
-

--- a/docs/ENGINEERING.md
+++ b/docs/ENGINEERING.md
@@ -505,109 +505,49 @@ yamllint .golangci.yml
 
 ## CI/CD Workflows
 
-### Workflow 1: Test and Lint
+All workflows run on push to main and on pull requests. Each workflow is focused on a single concern for clarity and maintainability.
+
+### Workflow 1: Test
 
 **File: `.github/workflows/test.yml`**
 
-```yaml
-name: Test and Lint
+Runs unit tests with coverage reporting.
 
-on:
-  push:
-    branches: [ main ]
-  pull_request:
-    branches: [ main ]
+- Runs tests with race detection
+- Checks coverage threshold (minimum 5%, target 60%)
+- Uploads coverage to Codecov
 
-jobs:
-  test:
-    name: Test
-    runs-on: ubuntu-latest
-    steps:
-      - uses: actions/checkout@v4
-      
-      - uses: actions/setup-go@v5
-        with:
-          go-version-file: go.mod
-          cache: true
-      
-      - name: Download dependencies
-        run: go mod download
-      
-      - name: Run tests
-        run: go test -v -race -coverprofile=coverage.out ./...
-      
-      - name: Upload coverage
-        uses: codecov/codecov-action@v4
-        with:
-          file: ./coverage.out
-          flags: unittests
-          name: codecov-gh-talk
-  
-  lint:
-    name: Lint
-    runs-on: ubuntu-latest
-    steps:
-      - uses: actions/checkout@v4
-      
-      - uses: actions/setup-go@v5
-        with:
-          go-version-file: go.mod
-          cache: true
-      
-      - name: golangci-lint
-        uses: golangci/golangci-lint-action@v6
-        with:
-          version: latest
-          args: --timeout=5m
-  
-  lint-markdown:
-    name: Lint Markdown
-    runs-on: ubuntu-latest
-    steps:
-      - uses: actions/checkout@v4
-      
-      - uses: actions/setup-node@v4
-        with:
-          node-version: '20'
-      
-      - name: Install markdownlint-cli
-        run: npm install -g markdownlint-cli
-      
-      - name: Lint .md files
-        run: markdownlint '**/*.md' --ignore node_modules
-      
-      - name: Lint .mdc files
-        run: markdownlint '**/*.mdc' --ignore node_modules
-  
-  format-check:
-    name: Format Check
-    runs-on: ubuntu-latest
-    steps:
-      - uses: actions/checkout@v4
-      
-      - uses: actions/setup-go@v5
-        with:
-          go-version-file: go.mod
-      
-      - name: Check gofmt
-        run: |
-          if [ -n "$(gofmt -l .)" ]; then
-            echo "Go code is not formatted:"
-            gofmt -d .
-            exit 1
-          fi
-      
-      - name: Check goimports
-        run: |
-          go install golang.org/x/tools/cmd/goimports@latest
-          if [ -n "$(goimports -l .)" ]; then
-            echo "Go imports are not formatted:"
-            goimports -d .
-            exit 1
-          fi
-```
+### Workflow 2: Lint
 
-### Workflow 2: Build Check
+**File: `.github/workflows/lint.yml`**
+
+Runs Go code linting with golangci-lint.
+
+- Uses golangci-lint with multiple enabled linters
+- 5 minute timeout
+- Checks code quality, style, and common issues
+
+### Workflow 3: Format
+
+**File: `.github/workflows/format.yml`**
+
+Checks code formatting with gofmt and goimports.
+
+- Verifies gofmt compliance
+- Verifies goimports compliance
+- Fails if any files need formatting
+
+### Workflow 4: Markdown Lint
+
+**File: `.github/workflows/markdown-lint.yml`**
+
+Lints all markdown files (.md and .mdc).
+
+- Checks markdown formatting and style
+- Uses markdownlint-cli with project configuration
+- Validates documentation quality
+
+### Workflow 5: Build Check
 
 **File: `.github/workflows/build.yml`**
 
@@ -648,7 +588,7 @@ jobs:
         shell: bash
 ```
 
-### Workflow 3: Release (Already Exists)
+### Workflow 6: Release
 
 **File: `.github/workflows/release.yml`**
 
@@ -688,7 +628,7 @@ git tag v0.1.0
 git push origin v0.1.0
 ```
 
-### Workflow 4: PR Validation
+### Workflow 7: PR Validation
 
 **File: `.github/workflows/pr.yml`**
 
@@ -752,7 +692,7 @@ jobs:
           config_file: .markdownlint.json
 ```
 
-### Workflow 5: Dependency Updates
+### Workflow 8: Dependency Updates
 
 **File: `.github/workflows/dependabot-auto-merge.yml`**
 

--- a/docs/ENGINEERING.md
+++ b/docs/ENGINEERING.md
@@ -628,9 +628,9 @@ git tag v0.1.0
 git push origin v0.1.0
 ```
 
-### Workflow 7: PR Validation
+### Workflow 7: PR Validation (Planned)
 
-**File: `.github/workflows/pr.yml`**
+**Planned file: `.github/workflows/pr.yml`** (not yet implemented)
 
 ```yaml
 name: PR Checks
@@ -692,9 +692,9 @@ jobs:
           config_file: .markdownlint.json
 ```
 
-### Workflow 8: Dependency Updates
+### Workflow 8: Dependency Updates (Planned)
 
-**File: `.github/workflows/dependabot-auto-merge.yml`**
+**Planned file: `.github/workflows/dependabot-auto-merge.yml`** (not yet implemented)
 
 ```yaml
 name: Dependabot Auto-merge


### PR DESCRIPTION
## Summary

Refactors the monolithic `test.yml` workflow into three separate, focused workflows for better separation of concerns and clearer CI reporting.

## Changes

### New Workflow Files

1. **`test.yml`** - Testing only
   - Runs unit tests with race detection
   - Checks coverage thresholds (5% min, 60% target)
   - Uploads coverage to Codecov

2. **`lint.yml`** - Go linting only
   - Runs golangci-lint with 5-minute timeout
   - Checks code quality, style, and common issues

3. **`format.yml`** - Format checking only
   - Verifies gofmt compliance
   - Verifies goimports compliance

### Documentation

- Updated **ENGINEERING.md** with new workflow structure
- Renumbered workflows 1-8 for clarity:
  1. Test
  2. Lint
  3. Format
  4. Markdown Lint
  5. Build Check
  6. Release
  7. PR Validation
  8. Dependency Updates

## Benefits

✅ **Clearer CI feedback** - Each concern has its own check
✅ **Easier debugging** - Failures are more specific
✅ **Better parallelization** - Workflows run independently
✅ **Improved maintainability** - Each file has a single responsibility
✅ **Consistent pattern** - Matches existing separate markdown-lint.yml

## Testing

- [x] All new workflow files are valid YAML
- [x] Markdown linting passes
- [x] Documentation updated
- [x] CI will validate workflows on this PR

---
🤖 *Generated by Cursor*