### PR TITLE
Update build matrix to test modern Go versions

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -14,7 +14,7 @@ jobs:
     strategy:
       matrix:
         os: [ubuntu-latest, macos-latest, windows-latest]
-        go: ['1.21', '1.22', '1.23']
+        go: ['1.23', '1.24']
     runs-on: ${{ matrix.os }}
     
     steps:


### PR DESCRIPTION
## Changes

Updated  to test only supported Go versions:

- ❌ Removed Go 1.21, 1.22 (below minimum requirement)
- ✅ Test Go 1.23 (minimum required version)
- ✅ Test Go 1.24 (current toolchain version)

## Motivation

The build matrix was testing Go versions 1.21-1.23, but `go.mod` requires:
```
go 1.23.0
toolchain go1.24.6
```

Testing versions below the minimum requirement is ineffective.

## Testing

CI will verify builds pass on all platforms with both Go versions.

Closes #28

---
🤖 *Generated by Cursor*